### PR TITLE
ci: Switch test suite from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,43 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        os:
+          - 'macos-10.15'
+          # still in private preview, see actions/virtual-environments#2486
+          # - 'macos-11.0'
+          - 'ubuntu-20.04'
+          - 'ubuntu-16.04'
+          - 'windows-2019'
+          - 'windows-2016'
+        python-version:
+          - '3.5'
+          - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+
+      - name: Package installation
+        run: pip install .
+
+      - name: Run tests
+        run: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-dist: xenial
-language: python
-python:
-  - "3.5"
-  - "3.6"
-  - "3.7"
-script:
-  - python setup.py test

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PyTrackDat — A pipeline for online data collection and management
 
 [![PyPI version](https://badge.fury.io/py/pytrackdat.svg)](https://badge.fury.io/py/pytrackdat)
-[![Build Status](https://travis-ci.org/pytrackdat/pytrackdat.svg?branch=master)](https://travis-ci.org/pytrackdat/pytrackdat)
+[![Build Status](https://github.com/pytrackdat/pytrackdat/workflows/Tests/badge.svg?branch=master)](https://github.com/pytrackdat/pytrackdat/actions?query=workflow%3ATests+branch%3Amaster)
 
 
 ## Overview


### PR DESCRIPTION
- Adds OS matrix run for Ubuntu 16.04 (Xenial), Ubuntu 20.04,
Windows Server 2016, Windows Server 2019, and macOS 10.15.
- Adds Python version matrix run for 3.5 through 3.9
- Adds a package installation step to check for correct pip
installation
- Updates badge in README to use GitHub Actions status

Travis has announced a new pricing model that's more restrictive to
macOS builds and sets build limits for Linux and Windows
environments[1]. In contrast, GitHub Actions offers unlimited minutes
for free in public repositories for Ubuntu, Windows Server, and macOS
builds[2].

[1] https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
[2] https://docs.github.com/en/actions/reference/usage-limits-billing-and-administration#about-billing-for-github-actions

See also: https://www.r-bloggers.com/2020/11/moving-away-from-travis-ci/

Resolves: #47